### PR TITLE
KT-86630: Introduce mocha browser runner for kotlin test

### DIFF
--- a/mocha-kotlin-reporter.d.ts
+++ b/mocha-kotlin-reporter.d.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+export interface TeamcityForWebReporterOptions {
+    flowId?: string;
+    useStdError?: boolean;
+    recordHookFailures?: boolean;
+    actualVsExpected?: boolean;
+    topLevelSuite?: string;
+    log?: (message: string) => void;
+    logError?: (message: string) => void;
+    Base?: Function;
+}
+
+export interface TeamcityForWebOptions {
+    reporterOptions?: TeamcityForWebReporterOptions;
+}
+
+export function TeamcityForWeb(runner: any, options?: TeamcityForWebOptions): void;
+export function Teamcity(runner: any, options?: TeamcityForWebOptions): void;

--- a/mocha-kotlin-reporter.js
+++ b/mocha-kotlin-reporter.js
@@ -24,42 +24,90 @@ import {
     TEST_START
 } from "./src/teamcity-format";
 
-const processPID = process.pid.toString();
-
-let Base, log, logError;
-
-Base = require('mocha').reporters.Base;
-log = console.log;
-logError = console.error;
-
 function isNil(value) {
     return value == null; 	// eslint-disable-line
 }
 
+function configureHtmlReporter(teamcityForWeb, Reporters, runner, options) {
+    if (!Reporters || !Reporters.HTML) {
+        console.error("Unable to configure HTML reporter: Mocha HTML reporter not found")
+        return;
+    }
+
+    const htmlAttached = !!(Reporters && Reporters.HTML
+        && typeof document !== 'undefined' && document.getElementById('mocha'));
+    if (htmlAttached) {
+        // Dirty hack: HTML has own prototype functions, we have to inherit them.
+        // But I don't want to extend TeamcityForWeb.prototype beforehand.
+        const instanceProto = Object.create(Reporters.HTML.prototype);
+        Object.setPrototypeOf(teamcityForWeb, instanceProto);
+        Reporters.HTML.call(teamcityForWeb, runner, options);
+    } else {
+        console.warn("No base reporter provided for Mocha." +
+            " Please configure Teamcity reporter with reporterOptions.Base = Mocha.reporters.Base or other.")
+    }
+}
+
+function configureBaseReporter(teamcityForWeb, Reporters, runner, options) {
+    Reporters.Base.call(teamcityForWeb, runner, options)
+}
+
 /**
- * Initialize a new `Teamcity` reporter.
+ * Core TeamCity reporter implementation that does not depend on Node.js `process` globals.
+ * Suitable for running Mocha in a browser. All options must be provided explicitly via
+ * `options.reporterOptions`.
+ *
+ * When running in a browser that exposes Mocha's HTML reporter via
+ * `window.Mocha.reporters.HTML` and the page contains a `<div id="mocha"></div>`,
+ * the HTML reporter is attached automatically so test progress is rendered on the
+ * page in addition to TeamCity service messages going to the console.
+ *
+ * Accepted reporterOptions:
+ *   - flowId            (string)
+ *   - useStdError       (boolean)
+ *   - recordHookFailures (boolean)
+ *   - actualVsExpected  (boolean)
+ *   - topLevelSuite     (string)
+ *   - log               (function) optional custom logger, defaults to console.log
+ *   - logError          (function) optional custom error logger, defaults to console.error
+ *   - Base              (function) optional Mocha Base reporter constructor; if provided,
+ *                       it will be invoked as Base.call(this, runner) to install
+ *                       Mocha's standard stats tracking on `this`. Ignored when the
+ *                       HTML reporter is auto-attached (HTML invokes Base itself).
  *
  * @param {Runner} runner
  * @param {options} options
  * @api public
  */
-
-function Teamcity(runner, options) {
+function TeamcityForWeb(runner, options) {
     options = options || {};
     const reporterOptions = options.reporterOptions || {};
-    let flowId, useStdError, recordHookFailures, actualVsExpected;
-    (reporterOptions.flowId) ? flowId = reporterOptions.flowId : flowId = process.env['MOCHA_TEAMCITY_FLOWID'] || processPID;
-    (reporterOptions.useStdError) ? useStdError = reporterOptions.useStdError : useStdError = process.env['USE_STD_ERROR'];
-    (reporterOptions.recordHookFailures) ? recordHookFailures = reporterOptions.recordHookFailures : recordHookFailures =
-        process.env['RECORD_HOOK_FAILURES'];
-    (reporterOptions.actualVsExpected) ? actualVsExpected = reporterOptions.actualVsExpected : actualVsExpected =
-        process.env['ACTUAL_VS_EXPECTED'];
-    (useStdError) ? useStdError = (useStdError.toLowerCase() === 'true') : useStdError = false;
-    (recordHookFailures) ? recordHookFailures = (recordHookFailures.toLowerCase() === 'true') : recordHookFailures = false;
-    actualVsExpected ? actualVsExpected = (actualVsExpected.toLowerCase() === 'true') : actualVsExpected = false;
-    Base.call(this, runner);
-    let stats = this.stats;
-    const topLevelSuite = reporterOptions.topLevelSuite || process.env['MOCHA_TEAMCITY_TOP_LEVEL_SUITE'];
+
+    const flowId = reporterOptions.flowId || '';
+    const useStdError = !!reporterOptions.useStdError;
+    const recordHookFailures = !!reporterOptions.recordHookFailures;
+    const actualVsExpected = !!reporterOptions.actualVsExpected;
+    const topLevelSuite = reporterOptions.topLevelSuite;
+
+    const log = reporterOptions.log || function (msg) { console.log(msg); };
+    const logError = reporterOptions.logError || function (msg) { console.error(msg); };
+
+    if (typeof reporterOptions.Base === 'function') {
+        if (typeof reporterOptions.alsoWithHtml !== 'undefined') {
+            console.warn("Reporter option 'alsoWithHtml' has no effect. Because custom reporterOptions.Base was provided.")
+        }
+        reporterOptions.Base.call(this, runner);
+    } else {
+        const alsoWithHtml = reporterOptions.alsoWithHtml || true;
+        const Reporters = (typeof window !== 'undefined' && window.Mocha && window.Mocha.reporters) || null;
+        if (alsoWithHtml) {
+            configureHtmlReporter(this, Reporters, runner, options)
+        } else {
+            configureBaseReporter(this, Reporters, runner, options)
+        }
+    }
+
+    const stats = this.stats || runner.stats;
 
     runner.on('suite', function (suite) {
         if (suite.root) {
@@ -126,7 +174,7 @@ function Teamcity(runner, options) {
 
     runner.on('end', function () {
         let duration;
-        (typeof stats === 'undefined') ? duration = null : duration = stats.duration;
+        (typeof stats === 'undefined' || stats === null) ? duration = null : duration = stats.duration;
         if (topLevelSuite) {
             isNil(duration) ? log(formatMessage(SUITE_END_NO_DURATION, topLevelSuite, flowId)) : log(
                 formatMessage(SUITE_END, topLevelSuite, duration, flowId));
@@ -134,9 +182,53 @@ function Teamcity(runner, options) {
     });
 }
 
+/**
+ * Node.js Mocha Teamcity reporter. Reads defaults from `process.env` and `process.pid`,
+ * then delegates to `TeamcityForWeb` for the actual event handling.
+ *
+ * @param {Runner} runner
+ * @param {options} options
+ * @api public
+ */
+function Teamcity(runner, options) {
+    options = options || {};
+    const reporterOptions = options.reporterOptions || {};
+
+    const processPID = process.pid.toString();
+
+    let flowId, useStdError, recordHookFailures, actualVsExpected;
+    (reporterOptions.flowId) ? flowId = reporterOptions.flowId : flowId = process.env['MOCHA_TEAMCITY_FLOWID'] || processPID;
+    (reporterOptions.useStdError) ? useStdError = reporterOptions.useStdError : useStdError = process.env['USE_STD_ERROR'];
+    (reporterOptions.recordHookFailures) ? recordHookFailures = reporterOptions.recordHookFailures : recordHookFailures =
+        process.env['RECORD_HOOK_FAILURES'];
+    (reporterOptions.actualVsExpected) ? actualVsExpected = reporterOptions.actualVsExpected : actualVsExpected =
+        process.env['ACTUAL_VS_EXPECTED'];
+    (useStdError) ? useStdError = (useStdError.toLowerCase() === 'true') : useStdError = false;
+    (recordHookFailures) ? recordHookFailures = (recordHookFailures.toLowerCase() === 'true') : recordHookFailures = false;
+    actualVsExpected ? actualVsExpected = (actualVsExpected.toLowerCase() === 'true') : actualVsExpected = false;
+    const topLevelSuite = reporterOptions.topLevelSuite || process.env['MOCHA_TEAMCITY_TOP_LEVEL_SUITE'];
+
+    const Base = require('mocha').reporters.Base;
+
+    TeamcityForWeb.call(this, runner, {
+        reporterOptions: {
+            flowId: flowId,
+            useStdError: useStdError,
+            recordHookFailures: recordHookFailures,
+            actualVsExpected: actualVsExpected,
+            topLevelSuite: topLevelSuite,
+            alsoWithHtml: true, // this is redundant as below we pass "Base"
+            Base: Base
+        }
+    });
+}
+
 
 /**
- * Expose `Teamcity`.
+ * Expose both `Teamcity` (Node.js) and `TeamcityForWeb` (browser).
  */
+module.exports = Teamcity;
+module.exports.Teamcity = Teamcity;
+module.exports.TeamcityForWeb = TeamcityForWeb;
 
-exports = module.exports = Teamcity;
+export { Teamcity, TeamcityForWeb };

--- a/mochaBrowser.ts
+++ b/mochaBrowser.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+/**
+ * Kotlin Test Runner adapter for browsers using Mocha.
+ * Check static/test.html for usage reference
+ */
+
+if (typeof window === 'undefined') {
+    throw new Error('This code can only be executed in a browser environment');
+}
+
+import {CliArgsParser, getDefaultCliDescription} from "./src/CliArgsParser";
+import {runWithFilteringAdapter} from "./src/Adapter";
+import {KotlinTestRunner} from "./src/KotlinTestRunner";
+import {TeamcityForWeb} from "./mocha-kotlin-reporter";
+
+const parser = new CliArgsParser(
+    getDefaultCliDescription(),
+    (exitCode) => {
+        throw new Error(`Exit with ${exitCode}`);
+    }
+);
+
+const preExistingConfig: KotlinTestBrowserRunnerConfig = (window.kotlinTestBrowserRunner as KotlinTestBrowserRunnerConfig) || {};
+
+const runnerState = {
+    reporter: preExistingConfig.reporter || TeamcityForWeb,
+    reporterOptions: preExistingConfig.reporterOptions || {},
+    mochaSetupOptions: preExistingConfig.mochaSetupOptions || {},
+    kotlinTestCliArguments: preExistingConfig.kotlinTestCliArguments || [],
+    adapterTransformer: preExistingConfig.adapterTransformer,
+    onComplete: preExistingConfig.onComplete,
+    mocha: preExistingConfig.mocha || window.mocha,
+    testsFinishedMarker: preExistingConfig.testsFinishedMarker || 'KOTLIN-TEST-FINISHED',
+}
+
+const runner: KotlinTestBrowserRunner = {
+    configure(config: KotlinTestBrowserRunnerConfig) {
+        if (config.reporter !== undefined) runnerState.reporter = config.reporter;
+        if (config.reporterOptions !== undefined) runnerState.reporterOptions = config.reporterOptions;
+        if (config.mochaSetupOptions !== undefined) runnerState.mochaSetupOptions = config.mochaSetupOptions;
+        if (config.kotlinTestCliArguments !== undefined) runnerState.kotlinTestCliArguments = config.kotlinTestCliArguments;
+        if (config.adapterTransformer !== undefined) runnerState.adapterTransformer = config.adapterTransformer;
+        if (config.onComplete !== undefined) runnerState.onComplete = config.onComplete;
+        if (config.mocha !== undefined) runnerState.mocha = config.mocha;
+        if (config.testsFinishedMarker !== undefined) runnerState.testsFinishedMarker = config.testsFinishedMarker;
+    },
+
+    run() {
+        const mocha = runnerState.mocha || window.mocha;
+        if (!mocha) {
+            throw new Error('Mocha is not available. Make sure mocha.js is loaded before invoking the Kotlin Test browser runner.');
+        }
+        mocha.run(function (failures: number) {
+            if (typeof runnerState.onComplete === 'function') {
+                runnerState.onComplete(failures);
+            }
+
+            // Kotlin Test Runner owner will close page after this marker.
+            console.log(runnerState.testsFinishedMarker);
+        });
+    }
+};
+
+const mochaInstance = runnerState.mocha || window.mocha;
+if (mochaInstance && typeof mochaInstance.setup === 'function') {
+    const setupOptions = Object.assign(
+        {ui: 'bdd'},
+        runnerState.mochaSetupOptions
+    );
+    mochaInstance.setup(setupOptions);
+    mochaInstance.reporter(runnerState.reporter, runnerState.reporterOptions);
+}
+
+const currentAdapterTransformer: (current: KotlinTestRunner) => KotlinTestRunner
+    = window.kotlinTest && window.kotlinTest.adapterTransformer;
+
+const adapterTransformer: (current: KotlinTestRunner) => KotlinTestRunner = (current) => {
+    const upstream = currentAdapterTransformer ? currentAdapterTransformer(current) : current;
+    const filtered = runWithFilteringAdapter(upstream, parser.parse(runnerState.kotlinTestCliArguments));
+    return typeof runnerState.adapterTransformer === 'function'
+        ? runnerState.adapterTransformer(filtered)
+        : filtered;
+};
+
+window.kotlinTest = {
+    adapterTransformer: adapterTransformer,
+    rawArgumentsProvider: window.kotlinTest && window.kotlinTest.rawArgumentsProvider
+};
+
+// User code now should describe tests via Jasmine spec
+// And call `window.kotlinTestBrowserRunner.run` when ready.
+// TODO: Add more explicit test integration mechanisms
+//  i.e. runner.runTests(function () {
+//      describe() { it() {} }
+//  })
+//  instead of doing it on window scope
+window.kotlinTestBrowserRunner = runner;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "LICENSE",
     "NOTICE",
     "README.md",
-    "dist/"
+    "dist/",
+    "src/",
+    "*.ts",
+    "*.d.ts",
+    ".js"
   ],
   "scripts": {
     "build": "copyfiles static/* dist/ & rollup -c rollup.config.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kotlin-web-helpers",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Kotlin/JS and Kotlin/Wasm utilities to work with Kotlin Gradle Plugin",
   "license": "Apache-2.0",
   "dependencies": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -41,6 +41,15 @@ export default [
         plugins: plugins()
     },
     {
+        input: './mochaBrowser.ts',
+        output: {
+            file: 'dist/kotlin-test-mocha-browser-runner.js',
+            format: 'esm',
+            sourcemap: true
+        },
+        plugins: plugins()
+    },
+    {
         input: './karma-kotlin-debug-plugin.js',
         output: {
             file: 'dist/karma-kotlin-debug-plugin.js',

--- a/static/test.html
+++ b/static/test.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Kotlin JS Tests</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
+</head>
+<body>
+<div id="mocha"></div>
+<script src="https://unpkg.com/mocha/mocha.js"></script>
+<script>
+    /** Kotlin test runner config */
+    config = {
+        /** Custom Mocha Reporter, note this will override "TeamcityForWeb" reporter */
+        // reporter: window.TeamcityForWeb,
+        /** Configure Mocha reporter (defaults TeamcityForWeb (mocha-kotlin-reporter.js) and HTML (official Mocha reporter)  */
+        reporterOptions: {
+            /** Disable HTML reporter, i.e. keep only TeamcityForWeb */
+            // alsoWithHtml: true,
+            /** Override Teamcity flowId, defaults to ?flowId=... query parameter */
+            // flowId: '',
+            /** Other options */
+            // recordHookFailures: true,
+            // actualVsExpected: true,
+        },
+        mochaSetupOptions: {
+            // timeout: 60_000, // ms
+            // slow: "75",
+            // etc...
+        },
+        /** Kotlin Test CLI arguments, currently supported only --include and --exclude in Gradle / IDEA wildcard format */
+        // kotlinTestCliArguments: ['--include', '*'],
+        /** Marker to indicate that tests finished, defaults to 'KOTLIN_TEST_RUN_FINISHED'. Page can be closed after that */
+        // testsFinishedMarker: 'MY KOTLIN TESTS RUN FINISHED'
+    }
+
+    /** Parse ?kotlinTestConfig={...} */
+    const urlParams = new URLSearchParams(window.location.search);
+    const configFromQueryParameter = urlParams.get('kotlinTestConfig') || {};
+    Object.assign(config, JSON.parse(configFromQueryParameter));
+
+    /** Place your custom configuration here */
+    // KOTLIN_TEST_BROWSER_CONFIG
+
+    window.kotlinTestBrowserRunner = window.kotlinTestBrowserRunner || {};
+    Object.assign(window.kotlinTestBrowserRunner, config)
+</script>
+<script src="tests.bundle-kotlinTestRunner.js"></script>
+<script>
+    // BEFORE tests.bundle.js LOAD
+</script>
+<script src="tests.bundle.js"></script>
+<script>
+    // BEFORE kotlinTestBrowserRunner run
+    window.addEventListener('load', function () {
+        window.kotlinTestBrowserRunner.run();
+        // AFTER kotlinTestBrowserRunner run
+    });
+</script>
+</body>
+</html>

--- a/window.d.ts
+++ b/window.d.ts
@@ -16,7 +16,91 @@ declare global {
 
         kotlinTest: {
             adapterTransformer: (current: KotlinTestRunner) => KotlinTestRunner
+            /**
+             * Configure global arguments provider
+             */
+            rawArgumentsProvider?: () => string[]
         }
+
+        /**
+         * Mocha global, available when the mocha browser bundle is loaded.
+         */
+        mocha: MochaGlobal
+
+        /**
+         * Extensibility hook for the Mocha-based Kotlin Test browser runner.
+         *
+         * Users may pre-populate this object (before loading the runner script) to
+         * customise behaviour, or read/modify it after the runner script has loaded.
+         */
+        kotlinTestBrowserRunner?: KotlinTestBrowserRunner
+    }
+
+    interface MochaGlobal {
+        setup(options: any): MochaGlobal
+        run(callback?: (failures: number) => void): any
+        reporters?: any
+        reporter(reporter: any, reporterOptions?: { [key: string]: any }): MochaGlobal
+        Runner?: any
+        [key: string]: any
+    }
+
+    interface KotlinTestBrowserRunnerConfig {
+        /**
+         * Mocha reporter constructor. Defaults to TeamcityForWeb (mocha-kotlin-reporter.js).
+         */
+        reporter?: any
+        /**
+         * Reporter-specific options (passed as `options.reporterOptions` to the reporter).
+         */
+        reporterOptions?: { [key: string]: any }
+        /**
+         * Options forwarded to `mocha.setup()`. Use this to switch UI, set timeout, etc.
+         * `ui` defaults to "bdd"; `reporter` is overridden by `reporter` above.
+         */
+        mochaSetupOptions?: { [key: string]: any }
+        /**
+         * Raw CLI-style arguments of Kotlin Test Runner specification (for example `--include`, `--exclude`).
+         * Defaults to reading the `kotlinTestRawArgsJson` URL query parameter:
+         *
+         * test.html?kotlinTestRawArgsJson=['--include', '*Foo', '--exclude', '*Bar']
+         *
+         * Test filters are compatible with Gradle and Intellij IDEA format.
+         */
+        kotlinTestCliArguments?: string[]
+        /**
+         * Additional adapter transformer applied after filtering. Allows users to inject
+         * extra decorators around the Kotlin Test runner (e.g. custom logging).
+         *
+         * Or extra
+         */
+        adapterTransformer?: (current: KotlinTestRunner) => KotlinTestRunner
+        /**
+         * Callback invoked when Mocha finishes the test run with the failure count.
+         */
+        onComplete?: (failures: number) => void
+        /**
+         * Reference to the Mocha global. Defaults to `window.mocha`.
+         */
+        mocha?: MochaGlobal
+
+        /**
+         * Marker that will be printed to console.log when all tests are finished and browser page can be closed.
+         * Defaults to query parameter `?kotlinTestFinishedMarker` || 'KOTLIN-TEST-FINISHED'
+         */
+        testsFinishedMarker?: string
+    }
+
+    interface KotlinTestBrowserRunner {
+        /**
+         * Merge new configuration into the runner. Must be called before `run()`.
+         */
+        configure(config: KotlinTestBrowserRunnerConfig): void
+
+        /**
+         * Run Mocha.
+         */
+        run(): void
     }
 }
 


### PR DESCRIPTION
[KT-86630](https://youtrack.jetbrains.com/issue/KT-86630/Introduce-mocha-browser-runner-for-kotlin-test-as-part-of-kotlin-web-helpers)

As part of Karma deprecation we want to run kotlin tests in browser. There is no direct replacement for Karma.
but as test runner engine we picked already supported Mocha. 

In this PR I've implemented a glue method that will connect mocha for browser with Kotlin Test environment.

Tests and this code will be bundled together and then test.html page will be opened via Playwright.
That is a subject of another review to Kotlin.